### PR TITLE
Use LZCOUNT pcode operation, show syscall number

### DIFF
--- a/data/languages/ppc_instructions_gekko_broadway.sinc
+++ b/data/languages/ppc_instructions_gekko_broadway.sinc
@@ -819,13 +819,13 @@
 #cntlzd  r0,r0 		0x7c 00 00 74
 :cntlzd A,S			is OP=31 & S & A & BITS_11_15=0 & XOP_1_10=58 & Rc=0
 {
-	A = countLeadingZeros(S);
+	A = lzcount(S);
 }
 
 #cntlzd. r0,r0		0x7c 00 00 75
 :cntlzd. A,S		is OP=31 & S & A & BITS_11_15=0 & XOP_1_10=58 & Rc=1
 {
-	A = countLeadingZeros(S);
+	A = lzcount(S);
 	cr0flags(A);
 }
 @endif
@@ -833,13 +833,13 @@
 #cntlzw  r0,r0 		0x7c 00 00 34
 :cntlzw A,S			is OP=31 & S & A & BITS_11_15=0 & XOP_1_10=26 & Rc=0
 {
-	A = countLeadingZeros(S:4);
+	A = lzcount(S:4);
 }
 
 #cntlzw. r0,r0		0x7c 00 00 35
 :cntlzw. A,S		is OP=31 & S & A & BITS_11_15=0 & XOP_1_10=26 & Rc=1
 {
-	A = countLeadingZeros(S:4);
+	A = lzcount(S:4);
 	cr0flags(A);
 }
 #===========================================================
@@ -3017,7 +3017,7 @@ define pcodeop lswxOp;
 #sc 		0x44 00 00 02
 :sc	LEV				is $(NOTVLE) & OP=17 & BITS_12_25=0 & LEV & BITS_2_4=0 & BIT_1=1 & BIT_0=0
 {
-	syscall();
+	syscall(r0);
 }
 
 #slbia		0x7C 00 03 E4


### PR DESCRIPTION
With `countLeadingZeroes` user-defined op
![image](https://github.com/user-attachments/assets/2a9df032-36ed-452b-b395-d69c344939e1)
With `LZCOUNT`
![image](https://github.com/user-attachments/assets/9d606bba-29bb-4801-b34e-7daf40e15c8c)

Syscall with number
![image](https://github.com/user-attachments/assets/31103eeb-24cd-4d8f-adac-f45788b77550)
